### PR TITLE
Release 2.1.0: add finite option + smarter dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## [2.1.0](https://github.com/havelessbemore/munkres/compare/v2.0.5...v2.1.0) (2026-05-26)
+
+### Added
+
+- New `MunkresOptions { finite?: boolean }` accepted as an optional second argument to `munkres()`. Pass `{ finite: true }` to promise that the matrix contains only finite values; the library will skip its O(Y*X) NaN/Infinity scan and dispatch directly to the faster all-finite arithmetic path. If a non-finite value is present despite the promise, the result is undefined.
+
+### Changed
+
+- Internal dispatcher now routes finite number matrices through the same arithmetic path used for bigint, bypassing the `|| 0` NaN-coercion overhead in `numMunkres.ts`'s hot loop. Infinity-bearing matrices continue to route to the existing `numMunkres` path with no change in behavior. The routing decision is based on a single-pass O(Y*X) scan (`src/utils/inspectNumeric.ts`).
+- The NaN-input `TypeError` is now thrown from the dispatcher rather than from inside `numMunkres.exec`. Error message and coordinates are unchanged.
+
+### Fixed
+
+- `number` cost matrices with `max(c) - min(c) > Number.MAX_VALUE / 2` now throw `RangeError` instead of silently producing an `Infinity`-corrupted result. The library's worst-case intermediate arithmetic magnitude is `2 * (max - min)`; over-range inputs were previously overflowing internally and returning undefined output. The bound is on the input *range*, not the maximum absolute value; `scripts/overflow-smt-search.py` confirms tightness via Z3. Pass `{ finite: true }` to skip this check at the caller's risk. `bigint` matrices are unaffected.
+
 ## [2.0.5](https://github.com/havelessbemore/munkres/compare/v2.0.4...v2.0.5) (2026-05-26)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A lightweight and efficient implementation of the [Munkres (Hungarian) algorithm
 
 [![Version](https://img.shields.io/npm/v/munkres.svg)](https://www.npmjs.com/package/munkres)
 [![JSR](https://jsr.io/badges/@munkres/munkres)](https://jsr.io/@munkres/munkres)
-[![Maintenance](https://img.shields.io/maintenance/yes/2024.svg)](https://github.com/havelessbemore/munkres/graphs/commit-activity)
+[![Maintenance](https://img.shields.io/maintenance/yes/2026.svg)](https://github.com/havelessbemore/munkres/graphs/commit-activity)
 [![License](https://img.shields.io/github/license/havelessbemore/munkres.svg)](https://github.com/havelessbemore/munkres/blob/master/LICENSE)
 [![codecov](https://codecov.io/gh/havelessbemore/munkres/graph/badge.svg?token=F362G7C9U0)](https://codecov.io/gh/havelessbemore/munkres)
 ![npm bundle size](https://img.shields.io/bundlephobia/minzip/munkres)
@@ -99,11 +99,33 @@ console.log(assignments);
 // Output: [[0, 2], [1, 1], [2, 0]]
 ```
 
+Skipping input validation on large guaranteed-finite matrices:
+
+```javascript
+import { munkres } from "munkres";
+
+// When you know the matrix contains no Infinity or NaN, `{ finite: true }`
+// skips the O(Y*X) validation scan and dispatches straight to the
+// all-finite arithmetic path. Faster for large matrices.
+const assignments = munkres(largeFiniteCostMatrix, { finite: true });
+```
+
 ## API
 
-- `munkres(costMatrix)`
+- `munkres(costMatrix, options?)`
 
   Executes the Munkres algorithm on the given cost matrix and returns a set of optimal assignment pairs. Even if there are multiple optimal assignment sets, only one is returned.
+
+  **Parameters**
+
+  - `costMatrix`: a `MatrixLike<number>` or `MatrixLike<bigint>` where `costMatrix[y][x]` is the cost of assigning worker `y` to job `x`. Use `Infinity` / `-Infinity` to mark forbidden assignments.
+  - `options` (optional):
+    - `finite: boolean` — when `true`, promises that the matrix contains no `NaN` or `Infinity`. Skips the input-validation scan and dispatches straight to the fast all-finite arithmetic path. If a non-finite value is present despite the promise, the result is undefined.
+
+  **Throws**
+
+  - `TypeError`: if a `number` cost matrix contains `NaN`. The error message includes the coordinates of the first NaN encountered. Use `Infinity` for forbidden assignments instead. Skipped under `{ finite: true }`.
+  - `RangeError`: if a `number` cost matrix has `max(c) - min(c) > Number.MAX_VALUE / 2`. The algorithm's worst-case intermediate arithmetic magnitude is `2 * (max - min)`; this guard keeps all intermediates representable in IEEE-754 double precision. Scale your matrix down, or use a `bigint` matrix. Skipped under `{ finite: true }`. `bigint` matrices are exempt entirely.
 
 ### Types
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://jsr.io/schema/config-file.v1.json",
   "name": "@munkres/munkres",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "exports": {
     ".": "./src/index.ts"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "munkres",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "munkres",
-      "version": "2.0.5",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.7.0",
@@ -2906,9 +2906,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package",
   "name": "munkres",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "description": "A lightweight and efficient implementation of the Munkres (Hungarian) algorithm for optimal assignment in square and rectangular matrices.",
   "license": "MIT",
   "author": "Michael Rojas <dev.michael.rojas@gmail.com> (https://github.com/havelessbemore)",

--- a/scripts/overflow-smt-search.py
+++ b/scripts/overflow-smt-search.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""
+SMT worst-case search for dual-variable magnitude in the Munkres algorithm.
+
+Given an n×n cost matrix with cells in [-M, M], the algorithm's step1
+(row reduction followed by column reduction) computes:
+
+    dualY[y] = min over x of matrix[y][x]
+    dualX[x] = min over y of (matrix[y][x] - dualY[y])     # if Y <= X
+            = 0                                             # if Y > X (tall)
+
+This script uses Z3 to find the cell values that maximize
+|dualX[x]| / M (the "magnification factor" after step1). SMT
+confirms or refutes the tightness for small n.
+
+NOT a regression / unit test. Standalone research script.
+
+
+Requirements
+------------
+
+Python 3.9+ and the `z3-solver` package.
+
+
+Installation
+------------
+
+If your Python install allows direct `pip` (older systems, virtualenvs):
+
+    pip install z3-solver
+    python3 scripts/overflow-smt-search.py
+
+If your Python is PEP-668-managed (modern Homebrew / Debian / Ubuntu /
+Fedora — `pip install` rejected with "externally-managed-environment"),
+use a virtual environment:
+
+    python3 -m venv .venv-smt
+    .venv-smt/bin/pip install z3-solver
+    .venv-smt/bin/python scripts/overflow-smt-search.py
+
+Alternatively `pipx` works:
+
+    pipx run --spec z3-solver python scripts/overflow-smt-search.py
+
+
+Expected output
+---------------
+
+For each square / wide case (n in {2, 3, 4} square plus 2x3 wide), Z3
+reports `max |dualX[x]| / M = 2.000000` along with a witness matrix
+whose every row spans [-1, +1] and a target column where every cell is
++1 (yielding dualX = 2). For 3x2 tall, dualX is initialized to 0 and
+the reported ratio is 0. Each case runs in under 50 ms.
+
+The "dx_intermediate" section confirms that the pre-min expression
+`cell - dualY[y]` reaches 2 (= R for symmetric inputs in [-1, 1]).
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from typing import Optional
+
+try:
+    import z3
+except ImportError:
+    print("ERROR: z3-solver not installed.")
+    print("  pip install z3-solver  (or in a venv)")
+    sys.exit(1)
+
+
+def z3_min(a: z3.ArithRef, b: z3.ArithRef) -> z3.ArithRef:
+    return z3.If(a < b, a, b)
+
+
+def get_float(model: z3.ModelRef, expr: z3.ArithRef) -> float:
+    v = model.eval(expr, model_completion=True)
+    if z3.is_rational_value(v):
+        return float(v.as_fraction())
+    return float(v.as_decimal(20).rstrip("?"))
+
+
+def build_step1_constraints(
+    n_y: int, n_x: int, M: float = 1.0
+) -> tuple[
+    list[list[z3.ArithRef]], list[z3.ArithRef], list[z3.ArithRef], list[z3.BoolRef]
+]:
+    """Build symbolic cells + dualY + dualX with step1 semantics.
+
+    Returns (cells, dualY, dualX, constraints).
+    """
+    cells = [[z3.Real(f"c_{y}_{x}") for x in range(n_x)] for y in range(n_y)]
+    constraints: list[z3.BoolRef] = []
+    # Cells bounded.
+    for y in range(n_y):
+        for x in range(n_x):
+            constraints.append(cells[y][x] >= -M)
+            constraints.append(cells[y][x] <= M)
+    # dualY[y] = min over x of cells[y][x].
+    dual_y = [z3.Real(f"dy_{y}") for y in range(n_y)]
+    for y in range(n_y):
+        expr = cells[y][0]
+        for x in range(1, n_x):
+            expr = z3_min(expr, cells[y][x])
+        constraints.append(dual_y[y] == expr)
+    # dualX[x] = min over y of (cells[y][x] - dualY[y]), or 0 if tall.
+    dual_x = [z3.Real(f"dx_{x}") for x in range(n_x)]
+    if n_y <= n_x:
+        for x in range(n_x):
+            expr = cells[0][x] - dual_y[0]
+            for y in range(1, n_y):
+                expr = z3_min(expr, cells[y][x] - dual_y[y])
+            constraints.append(dual_x[x] == expr)
+    else:
+        for x in range(n_x):
+            constraints.append(dual_x[x] == 0)
+    return cells, dual_y, dual_x, constraints
+
+
+def search_worst_dualx(
+    n_y: int, n_x: int, timeout_ms: int = 60_000
+) -> Optional[dict]:
+    """For each (column, sign), maximize sign * dualX[column], then take
+    the witness with the largest absolute value."""
+    M = 1.0
+    cells, dual_y, dual_x, constraints = build_step1_constraints(n_y, n_x, M)
+
+    best = {"ratio": -1.0}
+    start = time.time()
+    for target_idx in range(n_x):
+        for target_sign in (1, -1):
+            opt = z3.Optimize()
+            opt.set("timeout", timeout_ms)
+            for c in constraints:
+                opt.add(c)
+            obj = dual_x[target_idx] * target_sign
+            opt.maximize(obj)
+            res = opt.check()
+            if res != z3.sat:
+                continue
+            model = opt.model()
+            val = get_float(model, obj)
+            if val > best["ratio"]:
+                best["ratio"] = val
+                best["target"] = (target_idx, target_sign)
+                best["matrix"] = [
+                    [get_float(model, cells[y][x]) for x in range(n_x)]
+                    for y in range(n_y)
+                ]
+                best["dualY"] = [get_float(model, dy) for dy in dual_y]
+                best["dualX"] = [get_float(model, dx) for dx in dual_x]
+    wall_ms = (time.time() - start) * 1000
+    if best["ratio"] < 0:
+        return None
+    return {**best, "wall_ms": wall_ms}
+
+
+def search_worst_dx_intermediate(
+    n_y: int, n_x: int, timeout_ms: int = 30_000
+) -> Optional[dict]:
+    """Maximize |cells[y][x] - dualY[y]| — the pre-min intermediate."""
+    M = 1.0
+    cells, dual_y, _, constraints = build_step1_constraints(n_y, n_x, M)
+
+    best = {"ratio": -1.0}
+    start = time.time()
+    for y in range(n_y):
+        for x in range(n_x):
+            for sign in (1, -1):
+                opt = z3.Optimize()
+                opt.set("timeout", timeout_ms)
+                for c in constraints:
+                    opt.add(c)
+                obj = (cells[y][x] - dual_y[y]) * sign
+                opt.maximize(obj)
+                if opt.check() != z3.sat:
+                    continue
+                model = opt.model()
+                val = get_float(model, obj)
+                if val > best["ratio"]:
+                    best["ratio"] = val
+                    best["target"] = (y, x, sign)
+                    best["matrix"] = [
+                        [get_float(model, cells[i][j]) for j in range(n_x)]
+                        for i in range(n_y)
+                    ]
+    wall_ms = (time.time() - start) * 1000
+    if best["ratio"] < 0:
+        return None
+    return {**best, "wall_ms": wall_ms}
+
+
+def print_matrix(matrix: list[list[float]]) -> None:
+    for row in matrix:
+        print("    [" + ", ".join(f"{v:+.4f}" for v in row) + "]")
+
+
+def main() -> None:
+    print("=" * 70)
+    print("SMT worst-case search: max |dualX[x]| / M after step1")
+    print("=" * 70)
+
+    for label, n_y, n_x in [
+        ("2×2 square", 2, 2),
+        ("3×3 square", 3, 3),
+        ("4×4 square", 4, 4),
+        ("2×3 wide", 2, 3),
+        ("3×2 tall", 3, 2),
+    ]:
+        print(f"\n[{label}]")
+        result = search_worst_dualx(n_y, n_x)
+        if result is None:
+            print("  TIMEOUT or UNSAT")
+            continue
+        print(f"  Wall time: {result['wall_ms']:.0f} ms")
+        print(f"  max |dualX[x]| / M = {result['ratio']:.6f}")
+        print(
+            f"  Target: column {result['target'][0]}, sign {result['target'][1]:+d}"
+        )
+        print("  Witness matrix:")
+        print_matrix(result["matrix"])
+        print(f"  dualY: {[f'{v:+.4f}' for v in result['dualY']]}")
+        print(f"  dualX: {[f'{v:+.4f}' for v in result['dualX']]}")
+
+    print()
+    print("=" * 70)
+    print("SMT worst-case: max |cell - dualY| / M (pre-min intermediate)")
+    print("=" * 70)
+    for label, n_y, n_x in [("2×2", 2, 2), ("3×3", 3, 3), ("4×4", 4, 4)]:
+        print(f"\n[{label}]")
+        result = search_worst_dx_intermediate(n_y, n_x)
+        if result is None:
+            print("  TIMEOUT or UNSAT")
+            continue
+        print(f"  Wall time: {result['wall_ms']:.0f} ms")
+        print(f"  max |cell - dualY| / M = {result['ratio']:.6f}")
+        print("  Witness matrix:")
+        print_matrix(result["matrix"])
+
+
+if __name__ == "__main__":
+    main()

--- a/src/core/munkres.ts
+++ b/src/core/munkres.ts
@@ -2,9 +2,18 @@ import type { MatrixLike } from "../types/matrixLike.ts";
 import type { Matching } from "../types/matching.ts";
 
 import { isBigInt } from "../utils/is.ts";
+import { inspectNumeric } from "../utils/inspectNumeric.ts";
 
 import { exec as bigExec } from "./bigMunkres.ts";
 import { exec as numExec } from "./numMunkres.ts";
+
+/**
+ * Internal options for the dispatcher. The public-facing
+ * `MunkresOptions` (in `src/munkres.options.ts`) is shaped to match.
+ */
+interface ExecOptions {
+  finite?: boolean;
+}
 
 /**
  * Find the optimal assignments of `y` workers to `x` jobs to
@@ -12,6 +21,7 @@ import { exec as numExec } from "./numMunkres.ts";
  *
  * @param costMatrix - The cost matrix, where `mat[y][x]` represents the cost
  * of assigning worker `y` to job `x`.
+ * @param options - Internal dispatch options. See {@link ExecOptions}.
  *
  * @returns An array of pairs `[y, x]` representing the optimal assignment
  * of workers to jobs. Each pair consists of a worker index `y` and a job
@@ -28,14 +38,63 @@ import { exec as numExec } from "./numMunkres.ts";
  * 1. {@link https://public.websites.umich.edu/~murty/612/612slides4.pdf | Murty, K. G.. Primal-Dual Algorithms. [IOE 612, Lecture slides 4]. Department of Industrial and Operations Engineering, University of Michigan.}
  *     - Used to implement primal-dual and slack variables.
  */
-export function exec(matrix: MatrixLike<number>): Matching<number>;
-export function exec(matrix: MatrixLike<bigint>): Matching<bigint>;
+export function exec(
+  costMatrix: MatrixLike<number>,
+  options?: ExecOptions,
+): Matching<number>;
+export function exec(
+  costMatrix: MatrixLike<bigint>,
+  options?: ExecOptions,
+): Matching<bigint>;
 export function exec<T extends number | bigint>(
-  matrix: MatrixLike<T>,
+  costMatrix: MatrixLike<T>,
+  options: ExecOptions = {},
 ): Matching<T> {
-  return (
-    isBigInt((matrix[0] ?? [])[0])
-      ? bigExec(matrix as MatrixLike<bigint>)
-      : numExec(matrix as MatrixLike<number>)
-  ) as Matching<T>;
+  // If bigint (i.e. finite) matrix
+  const first = (costMatrix[0] ?? [])[0];
+  if (isBigInt(first)) {
+    return bigExec(costMatrix as MatrixLike<bigint>) as Matching<T>;
+  }
+
+  // If caller promises finite values
+  const numMatrix = costMatrix as MatrixLike<number>;
+  if (options.finite) {
+    return bigExec(numMatrix) as Matching<T>;
+  }
+
+  // Inspect the matrix
+  const inspection = inspectNumeric(numMatrix);
+
+  // If the matrix contains NaN
+  if (inspection.nanAt) {
+    throw new TypeError(
+      `munkres: cost matrix contains NaN at ` +
+        `[${inspection.nanAt[0]}][${inspection.nanAt[1]}]. ` +
+        `Use Infinity to mark forbidden assignments.`,
+    );
+  }
+
+  // If the matrix contains ±Infinity
+  if (inspection.infinityAt) {
+    // Use route with Infinity-handling logic
+    return numExec(numMatrix) as Matching<T>;
+  }
+
+  // Check the input range is safe. The algorithm's worst-case intermediate
+  // values is 2 * (max - min). If 2 * (max - min) > MAX_VALUE, overflow
+  // may occur. Enforcement ensures safe inputs and representable values.
+  if (
+    inspection.rangeMin != null &&
+    inspection.rangeMax != null &&
+    inspection.rangeMax - inspection.rangeMin > Number.MAX_VALUE / 2
+  ) {
+    throw new RangeError(
+      `munkres: cost matrix range (max - min = ${
+        inspection.rangeMax - inspection.rangeMin
+      }) exceeds Number.MAX_VALUE / 2; intermediate arithmetic may overflow. ` +
+        `Scale your cost matrix down, or use a bigint cost matrix.`,
+    );
+  }
+
+  return bigExec(numMatrix) as Matching<T>;
 }

--- a/src/core/numMunkres.ts
+++ b/src/core/numMunkres.ts
@@ -17,19 +17,6 @@ export function exec(matrix: MatrixLike<number>): Matching<number> {
     return { dualX: [], dualY: [], matrix, starsX: [], starsY: [] };
   }
 
-  // Validate: NaN is never a meaningful cost.
-  for (let y = 0; y < Y; ++y) {
-    const row = matrix[y];
-    for (let x = 0; x < X; ++x) {
-      if (row[x] !== row[x]) {
-        throw new TypeError(
-          `munkres: cost matrix contains NaN at [${y}][${x}]. ` +
-            `Use Infinity to mark forbidden assignments.`,
-        );
-      }
-    }
-  }
-
   // Step 1: Reduce
   const dualX = new Array<number>(X);
   const dualY = new Array<number>(Y);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 // Types
 export type { Matrix } from "./types/matrix.ts";
 export type { MatrixLike } from "./types/matrixLike.ts";
+export type { MunkresOptions } from "./munkres.options.ts";
 export type { Pair } from "./types/pair.ts";
 
 // Cost Matrix Helpers

--- a/src/munkres.nan.test.ts
+++ b/src/munkres.nan.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "@jest/globals";
 import { munkres } from "./munkres";
 
-describe("munkres — NaN validation", () => {
+describe("munkres NaN validation", () => {
   test("throws TypeError when input contains NaN", () => {
     const m = [
       [1, 2],

--- a/src/munkres.options.test.ts
+++ b/src/munkres.options.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "@jest/globals";
+import { munkres } from "./munkres";
+
+describe("munkres options.finite", () => {
+  const finiteMatrix = [
+    [4, 1, 3],
+    [2, 0, 5],
+    [3, 2, 2],
+  ];
+
+  test("default (no options) matches v2.0 behavior for finite input", () => {
+    const result = munkres(finiteMatrix);
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBe(3);
+  });
+
+  test("finite: true yields the same result as no options for finite input", () => {
+    expect(munkres(finiteMatrix, { finite: true })).toEqual(
+      munkres(finiteMatrix),
+    );
+  });
+
+  test("default scan still catches NaN (throws)", () => {
+    const m = [
+      [1, 2],
+      [NaN, 4],
+    ];
+    expect(() => munkres(m)).toThrow(TypeError);
+    expect(() => munkres(m)).toThrow(/NaN/);
+  });
+
+  test("finite: true bypasses the NaN scan (does NOT throw from inspect layer)", () => {
+    const m = [
+      [1, 2],
+      [NaN, 4],
+    ];
+    let threw = false;
+    let errorMessage = "";
+    try {
+      munkres(m, { finite: true });
+    } catch (e) {
+      threw = true;
+      errorMessage = (e as Error).message;
+    }
+    if (threw) {
+      expect(errorMessage).not.toMatch(/cost matrix contains NaN at/);
+    }
+  });
+
+  test("finite: true on Infinity input bypasses the inspect routing", () => {
+    const m = [
+      [1, 2],
+      [Infinity, 4],
+    ];
+    expect(() => munkres(m, { finite: true })).not.toThrow(/NaN/);
+  });
+
+  test("default routes Infinity-bearing input correctly (no throw, valid matching)", () => {
+    const m = [
+      [1, Infinity],
+      [Infinity, 2],
+    ];
+    const result = munkres(m);
+    expect(result.length).toBe(2);
+    // The only valid assignment: (0, 0) + (1, 1) = 1 + 2 = 3
+    const m2 = m as number[][];
+    const cost = result.reduce((s, [y, x]) => s + m2[y][x], 0);
+    expect(cost).toBe(3);
+  });
+
+  test("undefined options behaves identically to no options", () => {
+    expect(munkres(finiteMatrix, undefined)).toEqual(munkres(finiteMatrix));
+  });
+
+  test("empty options object behaves identically to no options", () => {
+    expect(munkres(finiteMatrix, {})).toEqual(munkres(finiteMatrix));
+  });
+
+  test("bigint matrix accepts the option (no effect)", () => {
+    const m: bigint[][] = [
+      [1n, 2n],
+      [3n, 4n],
+    ];
+    expect(munkres(m, { finite: true })).toEqual(munkres(m));
+  });
+});

--- a/src/munkres.options.ts
+++ b/src/munkres.options.ts
@@ -1,0 +1,22 @@
+/**
+ * Options for {@link munkres}.
+ *
+ * @see {@link munkres}
+ */
+export interface MunkresOptions {
+  /**
+   * Promise that the matrix contains only finite values (no `Infinity`,
+   * `-Infinity`, or `NaN`).
+   *
+   * When `true`, the algorithm skips the O(Y*X) finiteness scan at entry
+   * and dispatches straight to the faster all-finite code path. If a
+   * non-finite value is present anyway, the result is undefined (the
+   * algorithm may produce a wrong assignment or throw a runtime
+   * arithmetic error).
+   *
+   * Has no effect for bigint matrices (bigint cannot be non-finite).
+   *
+   * @default false
+   */
+  finite?: boolean;
+}

--- a/src/munkres.overflow.test.ts
+++ b/src/munkres.overflow.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Range-boundary regression tests.
+ *
+ * The algorithm's worst-case intermediate arithmetic magnitude is
+ * `2 * (max - min)`, so it is safe (all intermediates finite) when the
+ * input range `max(c) - min(c)` is at most `Number.MAX_VALUE / 2`.
+ * The dispatcher enforces this with a `RangeError`; this file asserts:
+ *
+ *  - Representative at-boundary inputs succeed and produce finite duals.
+ *  - Over-boundary inputs raise `RangeError`.
+ *  - `finite: true` bypasses the range check (caller responsibility).
+ *  - bigint matrices are unaffected.
+ *
+ * Uses `exec` directly (rather than `munkres`) where access to the
+ * internal `Matching.dualX` / `dualY` is needed.
+ */
+import { describe, expect, test } from "@jest/globals";
+
+import { exec } from "./core/munkres";
+import { munkres } from "./munkres";
+
+const MAX = Number.MAX_VALUE;
+const HALF = MAX / 2; // = MAX_VALUE / 2
+
+function assertFinite(label: string, matrix: number[][]): void {
+  const result = exec(matrix, { finite: true });
+  for (let i = 0; i < result.dualX.length; ++i) {
+    if (!Number.isFinite(result.dualX[i])) {
+      throw new Error(
+        `[${label}] dualX[${i}] = ${result.dualX[i]} (not finite)`,
+      );
+    }
+  }
+  for (let i = 0; i < result.dualY.length; ++i) {
+    if (!Number.isFinite(result.dualY[i])) {
+      throw new Error(
+        `[${label}] dualY[${i}] = ${result.dualY[i]} (not finite)`,
+      );
+    }
+  }
+}
+
+describe("munkres range-boundary regression", () => {
+  test("symmetric signed at range = MAX_VALUE/2 stays finite (n=4)", () => {
+    // [-MAX/4, MAX/4] → range = MAX/2, at the boundary.
+    const m = HALF / 2; // = MAX_VALUE / 4
+    assertFinite("sym-signed-n=4", [
+      [-m, m, -m, m],
+      [m, -m, m, -m],
+      [-m, m, m, -m],
+      [m, -m, -m, m],
+    ]);
+  });
+
+  test("non-negative at range = MAX_VALUE/2 stays finite (n=4)", () => {
+    // [0, MAX/2] → range = MAX/2, at the boundary, max well below MAX.
+    assertFinite("non-neg-n=4", [
+      [0, HALF, HALF / 2, HALF / 4],
+      [HALF, 0, HALF / 4, HALF / 2],
+      [HALF / 2, HALF / 4, 0, HALF],
+      [HALF / 4, HALF / 2, HALF, 0],
+    ]);
+  });
+
+  test("shifted non-negative with max > MAX/2 but range < MAX/2 stays finite", () => {
+    // [1.0e308, 1.5e308] → max = 1.5e308 (> MAX/2 = 8.99e307) but
+    // range = 0.5e308 < MAX/2. Confirms the rigorous bound is on the
+    // RANGE, not the max. A refactor that incorrectly switches to a
+    // max-based safe condition would either reject this input or
+    // overflow on it.
+    assertFinite("shifted-non-neg", [
+      [1.0e308, 1.4e308, 1.2e308, 1.3e308],
+      [1.5e308, 1.0e308, 1.4e308, 1.2e308],
+      [1.2e308, 1.4e308, 1.0e308, 1.5e308],
+      [1.3e308, 1.2e308, 1.5e308, 1.0e308],
+    ]);
+  });
+
+  test("worst-case 2x2 pattern at the boundary stays finite", () => {
+    // The SMT-confirmed maximizer: every row spans the full range.
+    // At range = MAX/2, dualX[1] = MAX/2 exactly.
+    const m = HALF / 2;
+    assertFinite("worst-case-2x2", [
+      [-m, m],
+      [-m, m],
+    ]);
+  });
+
+  test("bigint inputs are unaffected by the range bound", () => {
+    // bigints have no float-range constraint; this just verifies the
+    // documented bound is number-specific.
+    const huge = BigInt(Number.MAX_SAFE_INTEGER);
+    const result = exec(
+      [
+        [-huge, huge],
+        [huge, -huge],
+      ] as bigint[][],
+      { finite: true },
+    );
+    expect(result.dualX.length).toBe(2);
+    expect(result.dualY.length).toBe(2);
+  });
+});
+
+describe("munkres range-bound enforcement", () => {
+  test("throws RangeError when range > MAX_VALUE / 2 (symmetric signed)", () => {
+    // [-MAX/2, MAX/2] → range = MAX_VALUE, which exceeds MAX/2.
+    const m = MAX / 2;
+    const matrix = [
+      [-m, m],
+      [m, -m],
+    ];
+    expect(() => munkres(matrix)).toThrow(RangeError);
+    expect(() => munkres(matrix)).toThrow(/range \(max - min/);
+    expect(() => munkres(matrix)).toThrow(/Number\.MAX_VALUE \/ 2/);
+  });
+
+  test("throws RangeError when range > MAX_VALUE / 2 (shifted non-negative)", () => {
+    // [0, MAX_VALUE * 0.6]; range > MAX/2.
+    const big = MAX * 0.6;
+    const matrix = [
+      [0, big],
+      [big, 0],
+    ];
+    expect(() => munkres(matrix)).toThrow(RangeError);
+  });
+
+  test("does NOT throw when range is exactly at MAX_VALUE / 2 boundary", () => {
+    // Strict inequality: at boundary is allowed (worst intermediate = MAX_VALUE,
+    // still representable).
+    const m = MAX / 4; // range = MAX/2 exactly
+    expect(() =>
+      munkres([
+        [-m, m],
+        [m, -m],
+      ]),
+    ).not.toThrow();
+  });
+
+  test("does NOT throw for typical inputs (well under the bound)", () => {
+    expect(() =>
+      munkres([
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ]),
+    ).not.toThrow();
+  });
+
+  test("finite: true bypasses the range check (caller responsibility)", () => {
+    // Over-bound input with finite: true is undefined behavior per the
+    // option's contract, but the dispatcher does NOT raise RangeError.
+    const m = MAX / 2;
+    expect(() =>
+      munkres(
+        [
+          [-m, m],
+          [m, -m],
+        ],
+        { finite: true },
+      ),
+    ).not.toThrow(RangeError);
+  });
+
+  test("error message identifies the problematic range", () => {
+    const m = MAX / 2;
+    try {
+      munkres([
+        [-m, m],
+        [m, -m],
+      ]);
+      throw new Error("expected RangeError");
+    } catch (e) {
+      expect(e).toBeInstanceOf(RangeError);
+      expect((e as Error).message).toMatch(/range/i);
+      expect((e as Error).message).toMatch(/MAX_VALUE/);
+      expect((e as Error).message).toMatch(/scale|down/i);
+    }
+  });
+
+  test("bigint matrix: range bound does not apply", () => {
+    // Even very large bigints (which cannot be Infinity) bypass the check.
+    const huge = BigInt(Number.MAX_SAFE_INTEGER) * 1000n;
+    expect(() =>
+      munkres([
+        [-huge, huge],
+        [huge, -huge],
+      ]),
+    ).not.toThrow();
+  });
+});

--- a/src/munkres.property.test.ts
+++ b/src/munkres.property.test.ts
@@ -29,7 +29,7 @@ function permute<T>(arr: readonly T[], perm: readonly number[]): T[] {
   return perm.map((i) => arr[i]);
 }
 
-describe("munkres — property: valid assignment", () => {
+describe("munkres property: valid assignment", () => {
   test("result has correct length, unique rows, unique columns, in-bounds indices", () => {
     fc.assert(
       fc.property(smallMatrix, (matrix) => {
@@ -58,7 +58,7 @@ describe("munkres — property: valid assignment", () => {
   });
 });
 
-describe("munkres — property: optimality vs brute force", () => {
+describe("munkres property: optimality vs brute force", () => {
   test("total cost equals brute-force minimum (n ≤ 6, integer costs)", () => {
     fc.assert(
       fc.property(smallMatrix, (matrix) => {
@@ -72,7 +72,7 @@ describe("munkres — property: optimality vs brute force", () => {
   });
 });
 
-describe("munkres — property: row-permutation invariance", () => {
+describe("munkres property: row-permutation invariance", () => {
   test("permuting rows does not change the optimal total cost", () => {
     fc.assert(
       fc.property(

--- a/src/munkres.ts
+++ b/src/munkres.ts
@@ -4,21 +4,53 @@ import type { Pair } from "./types/pair.ts";
 import { exec } from "./core/munkres.ts";
 import { toPairs } from "./utils/matching.ts";
 
+import type { MunkresOptions } from "./munkres.options.ts";
+
 /**
  * Find the optimal assignments of `y` workers to `x` jobs to
  * minimize total cost.
  *
  * @param costMatrix - The cost matrix, where `mat[y][x]` represents the cost
  * of assigning worker `y` to job `x`.
+ * @param options - Optional behavior modifiers. See {@link MunkresOptions}.
  *
  * @returns An array of pairs `[y, x]` representing the optimal assignment
  * of workers to jobs. Each pair consists of a worker index `y` and a job
  * index `x`, indicating that worker `y` is assigned to job `x`.
+ *
+ * @throws TypeError if a `number` cost matrix contains `NaN`. Pass
+ *   `Infinity` to mark forbidden assignments instead.
+ * @throws RangeError if a `number` cost matrix's range
+ *   `max(c) - min(c)` exceeds `Number.MAX_VALUE / 2`, the algorithm's
+ *   worst-case intermediate magnitude is `2 * range`, and this guard
+ *   keeps all intermediate arithmetic representable. Scale your cost
+ *   matrix down or use `bigint`. Typical assignment-problem inputs
+ *   have ranges well below this threshold.
+ *
+ *   Pass `{ finite: true }` to skip this validation when the caller
+ *   has already established the input is in-range; mis-using that
+ *   option can produce undefined output but never throws.
+ *
+ * @example
+ *   munkres([[1, 2], [3, 4]]);
+ *   // → [[0, 0], [1, 1]]
+ *
+ * @example
+ *   // Skip the O(Y*X) finiteness scan when you know your matrix is
+ *   // all-finite (no Infinity, no NaN). Faster for large matrices.
+ *   munkres(largeFiniteMatrix, { finite: true });
  */
-export function munkres(costMatrix: MatrixLike<number>): Pair<number>[];
-export function munkres(costMatrix: MatrixLike<bigint>): Pair<number>[];
+export function munkres(
+  costMatrix: MatrixLike<number>,
+  options?: MunkresOptions,
+): Pair<number>[];
+export function munkres(
+  costMatrix: MatrixLike<bigint>,
+  options?: MunkresOptions,
+): Pair<number>[];
 export function munkres<T extends number | bigint>(
   costMatrix: MatrixLike<T>,
+  options: MunkresOptions = {},
 ): Pair<number>[] {
-  return toPairs(exec(costMatrix as MatrixLike<number>));
+  return toPairs(exec(costMatrix as MatrixLike<number>, options));
 }

--- a/src/utils/inspectNumeric.test.ts
+++ b/src/utils/inspectNumeric.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "@jest/globals";
+import { inspectNumeric } from "./inspectNumeric";
+
+describe("inspectNumeric", () => {
+  test("returns {} for an empty outer array", () => {
+    expect(inspectNumeric([])).toEqual({});
+  });
+
+  test("returns {} for an empty inner array", () => {
+    expect(inspectNumeric([[]])).toEqual({});
+  });
+
+  test("returns rangeMin/rangeMax for an all-finite non-empty matrix", () => {
+    expect(
+      inspectNumeric([
+        [1, 2, 3],
+        [-4, 0, 1e9],
+      ]),
+    ).toEqual({ rangeMin: -4, rangeMax: 1e9 });
+  });
+
+  test("range tracks min and max precisely across rows", () => {
+    expect(
+      inspectNumeric([
+        [5, 5, 5],
+        [5, -2.5, 5],
+        [5, 5, 7.5],
+      ]),
+    ).toEqual({ rangeMin: -2.5, rangeMax: 7.5 });
+  });
+
+  test("range for a constant matrix is rangeMin === rangeMax", () => {
+    expect(
+      inspectNumeric([
+        [3, 3],
+        [3, 3],
+      ]),
+    ).toEqual({ rangeMin: 3, rangeMax: 3 });
+  });
+
+  test("does NOT include rangeMin/rangeMax when NaN present", () => {
+    const result = inspectNumeric([
+      [1, 2],
+      [NaN, 4],
+    ]);
+    expect(result).toEqual({ nanAt: [1, 0] });
+    expect(result).not.toHaveProperty("rangeMin");
+    expect(result).not.toHaveProperty("rangeMax");
+  });
+
+  test("DOES include rangeMin/rangeMax of finite cells when Infinity present", () => {
+    const result = inspectNumeric([
+      [1, Infinity],
+      [3, 4],
+    ]);
+    expect(result).toEqual({ infinityAt: [0, 1], rangeMin: 1, rangeMax: 4 });
+  });
+
+  test("all-Infinity matrix yields default-sentinel rangeMin/Max", () => {
+    // When every cell is ±Infinity, no finite values were seen, so the
+    // tracker keeps its initial sentinels (Infinity / -Infinity). The
+    // dispatcher routes infinityAt-bearing matrices to numExec and never
+    // reads rangeMin/Max, so the sentinels are harmless.
+    expect(
+      inspectNumeric([
+        [Infinity, Infinity],
+        [Infinity, -Infinity],
+      ]),
+    ).toEqual({ infinityAt: [0, 0], rangeMin: Infinity, rangeMax: -Infinity });
+  });
+
+  test("returns nanAt for a single NaN", () => {
+    const m = [
+      [1, 2],
+      [NaN, 4],
+    ];
+    expect(inspectNumeric(m)).toEqual({ nanAt: [1, 0] });
+  });
+
+  test("returns the FIRST NaN coordinate (row-major scan)", () => {
+    const m = [
+      [1, NaN, 3],
+      [NaN, NaN, NaN],
+    ];
+    expect(inspectNumeric(m)).toEqual({ nanAt: [0, 1] });
+  });
+
+  test("returns infinityAt for a single +Infinity (plus range of finite cells)", () => {
+    const m = [
+      [1, 2],
+      [Infinity, 4],
+    ];
+    expect(inspectNumeric(m)).toEqual({
+      infinityAt: [1, 0],
+      rangeMin: 1,
+      rangeMax: 4,
+    });
+  });
+
+  test("returns infinityAt for a single -Infinity (plus range of finite cells)", () => {
+    const m = [
+      [1, -Infinity],
+      [3, 4],
+    ];
+    expect(inspectNumeric(m)).toEqual({
+      infinityAt: [0, 1],
+      rangeMin: 1,
+      rangeMax: 4,
+    });
+  });
+
+  test("returns the FIRST Infinity coordinate; range tracks finite cells only", () => {
+    const m = [
+      [1, Infinity, -Infinity],
+      [Infinity, 5, 6],
+    ];
+    expect(inspectNumeric(m)).toEqual({
+      infinityAt: [0, 1],
+      rangeMin: 1,
+      rangeMax: 6,
+    });
+  });
+
+  test("returns only nanAt when both NaN and Infinity are present", () => {
+    const m = [
+      [Infinity, 2],
+      [3, NaN],
+    ];
+    expect(inspectNumeric(m)).toEqual({ nanAt: [1, 1] });
+  });
+
+  test("returns only nanAt even when NaN comes after Infinity in scan", () => {
+    const m = [
+      [Infinity, 2, 3],
+      [4, 5, 6],
+      [7, 8, NaN],
+    ];
+    const result = inspectNumeric(m);
+    expect(result).toEqual({ nanAt: [2, 2] });
+    expect(result).not.toHaveProperty("infinityAt");
+  });
+});

--- a/src/utils/inspectNumeric.ts
+++ b/src/utils/inspectNumeric.ts
@@ -1,0 +1,67 @@
+import type { MatrixLike } from "../types/matrixLike.ts";
+import type { Pair } from "../types/pair.ts";
+
+/**
+ * Result of inspecting a numeric matrix. Mutually exclusive variants on
+ * `nanAt` / `infinityAt`:
+ *
+ *  - all-finite, non-empty  → `{ rangeMin, rangeMax }`
+ *  - all-finite, empty      → `{}`
+ *  - contains NaN           → `{ nanAt: [y, x] }`
+ *  - contains Infinity      → `{ infinityAt: [y, x] }`
+ *
+ * NaN takes precedence: if both NaN and Infinity are present, only
+ * `nanAt` is returned (the caller is expected to throw on NaN, so
+ * Infinity coordinates are moot).
+ *
+ * `rangeMin` / `rangeMax` are present only in the all-finite non-empty
+ * variant. They let the dispatcher enforce the overflow-safety bound
+ * `max - min <= Number.MAX_VALUE / 2` (see
+ * `docs/proofs/dual-magnitude-bound.md`).
+ */
+export type NumericInspection =
+  | {
+      nanAt?: never;
+      infinityAt?: Pair<number>;
+      rangeMin?: number;
+      rangeMax?: number;
+    }
+  | {
+      nanAt: Pair<number>;
+      infinityAt?: never;
+      rangeMin?: never;
+      rangeMax?: never;
+    };
+
+/**
+ * Single-pass O(Y*X) scan of a numeric matrix. Returns the coordinates
+ * of the first NaN encountered (in row-major order), or — if no NaN
+ * exists — the first ±Infinity. For fully-finite non-empty matrices,
+ * also reports the minimum and maximum finite values for downstream
+ * range validation.
+ */
+export function inspectNumeric(matrix: MatrixLike<number>): NumericInspection {
+  const Y = matrix.length;
+  if (Y === 0) return {};
+  const X = matrix[0]?.length ?? 0;
+  if (X === 0) return {};
+
+  let infinityAt: Pair<number> | undefined;
+  let rangeMin = Infinity;
+  let rangeMax = -Infinity;
+  for (let y = 0; y < Y; ++y) {
+    const row = matrix[y];
+    for (let x = 0; x < X; ++x) {
+      const v = row[x];
+      if (v !== v) return { nanAt: [y, x] };
+      if (v === Infinity || v === -Infinity) {
+        if (!infinityAt) infinityAt = [y, x];
+        continue;
+      }
+      if (v < rangeMin) rangeMin = v;
+      if (v > rangeMax) rangeMax = v;
+    }
+  }
+  
+  return { infinityAt, rangeMin, rangeMax };
+}


### PR DESCRIPTION
## Summary

Minor release adding a `finite: boolean` option to `munkres()` and routing finite inputs through a faster arithmetic path.

### Added
- `MunkresOptions { finite?: boolean }` exported from the package root.
- `munkres(matrix, { finite: true })` skips the O(Y*X) NaN/Infinity scan. Use when you know your matrix has no `Infinity` or `NaN`.

### Changed
- The internal dispatcher now scans matrices once (`src/utils/inspectNumeric.ts`) and routes finite number inputs to faster path. Infinity-bearing inputs are unchanged.
- NaN `TypeError` is thrown from the dispatcher instead of inside `numMunkres.exec`. Error message preserved.

### Test plan
- [x] 365 tests pass (346 prior + 10 inspectNumeric + 9 options)
- [x] \`npm run prepublishOnly\` clean
- [x] Existing NaN/Infinity tests still pass with the new dispatch