### PR TITLE
perf: avoid per-call empty-options allocation in dispatcher

### DIFF
--- a/src/core/munkres.ts
+++ b/src/core/munkres.ts
@@ -48,17 +48,16 @@ export function exec(
 ): Matching<bigint>;
 export function exec<T extends number | bigint>(
   costMatrix: MatrixLike<T>,
-  options: ExecOptions = {},
+  options?: ExecOptions,
 ): Matching<T> {
   // If bigint (i.e. finite) matrix
-  const first = (costMatrix[0] ?? [])[0];
-  if (isBigInt(first)) {
+  if (isBigInt((costMatrix[0] ?? [])[0])) {
     return bigExec(costMatrix as MatrixLike<bigint>) as Matching<T>;
   }
 
   // If caller promises finite values
   const numMatrix = costMatrix as MatrixLike<number>;
-  if (options.finite) {
+  if (options?.finite) {
     return bigExec(numMatrix) as Matching<T>;
   }
 

--- a/src/munkres.ts
+++ b/src/munkres.ts
@@ -50,7 +50,7 @@ export function munkres(
 ): Pair<number>[];
 export function munkres<T extends number | bigint>(
   costMatrix: MatrixLike<T>,
-  options: MunkresOptions = {},
+  options?: MunkresOptions,
 ): Pair<number>[] {
   return toPairs(exec(costMatrix as MatrixLike<number>, options));
 }


### PR DESCRIPTION
## Summary

Removes the throwaway `{}` allocation that `options: ExecOptions = {}` and `options: MunkresOptions = {}` forced on every call to the dispatcher and the public API. The bigint hot path doesn't read `options` at all; the per-call allocation was pure waste, and may have been responsible for the small bigint benchmark regression observed after v2.1.0 was merged ([dashboard](https://havelessbemore.github.io/munkres/dev/bench/)).

Concretely:
- `src/core/munkres.ts:exec(costMatrix, options: ExecOptions = {})` → `options?: ExecOptions`; reader switches to `options?.finite`.
- `src/munkres.ts:munkres(costMatrix, options: MunkresOptions = {})` → `options?: MunkresOptions`.
- Inlined the one-use `const first = (costMatrix[0] ?? [])[0]` temporary.

Lands ahead of the v2.1.0 tag/release — the v2.1.0 PR has merged to main but no tag exists yet, so this fix can ship in the same release.

## Test plan

- [x] 382 tests pass (no behavior change)
- [x] `npm run prepublishOnly` clean