### PR TITLE
bench: free matrix in afterEach to bound heap to one at a time

### DIFF
--- a/benchmarks/munkres.bench.ts
+++ b/benchmarks/munkres.bench.ts
@@ -42,7 +42,24 @@ const setMode = (_: unknown, mode: "run" | "warmup") => {
 // and includes N=256 (65536 cells) and up — the point where matrices
 // start landing in V8's old generation rather than nursery.
 const HEAVY_CELLS = 1 << 15; // 32768 cells; N >= 256 for square matrices
-const sweepIfHeavy = (cells: number) => (cells >= HEAVY_CELLS ? sweep : undefined);
+
+// `afterEach` hook for heavy tasks: drop the matrix reference AND force
+// a sync GC before the next iteration's `beforeEach` allocates a fresh
+// matrix. Without the explicit clear-then-GC sequence, the JS
+// expression `mat = gen(...)` keeps the old matrix referenced until
+// `gen()` returns — which means BOTH matrices coexist briefly during
+// allocation of the new one. For 8192x8192 bigint that's 2 × ~1.6 GB
+// of boxed BigInts, exceeding any reasonable `--max-old-space-size`.
+function makeAfterEach(
+  cells: number,
+  clear: () => void,
+): (() => void) | undefined {
+  if (cells < HEAVY_CELLS) return undefined;
+  return () => {
+    clear();
+    sweep();
+  };
+}
 
 // `time: 1000` (tinybench default) gives fast tasks the sample density
 // they need; the 50-iter floor pins slow tasks. `warmupIterations: 1,
@@ -72,10 +89,11 @@ for (let i = 1; i <= 13; ++i) {
   let mat: Matrix<number>;
   bench.add(`${N}x${N}`, () => munkres(mat), {
     beforeEach: () => {
-      mat = [];
       mat = gen(N, N, genInt);
     },
-    afterEach: sweepIfHeavy(N * N),
+    afterEach: makeAfterEach(N * N, () => {
+      mat = [];
+    }),
   });
 }
 
@@ -87,10 +105,11 @@ for (let i = 1; i <= 12; ++i) {
   let mat: Matrix<bigint>;
   bench.add(`${N}x${N}`, () => munkres(mat), {
     beforeEach: () => {
-      mat = [];
       mat = gen(N, N, genBig);
     },
-    afterEach: sweepIfHeavy(N * N),
+    afterEach: makeAfterEach(N * N, () => {
+      mat = [];
+    }),
   });
 }
 
@@ -107,10 +126,11 @@ suite.add(
   let mat: Matrix<bigint>;
   bench.add(`${N}x${N}`, () => munkres(mat), {
     beforeEach: () => {
-      mat = [];
       mat = gen(N, N, genBig);
     },
-    afterEach: sweepIfHeavy(N * N),
+    afterEach: makeAfterEach(N * N, () => {
+      mat = [];
+    }),
   });
 }
 


### PR DESCRIPTION
## Summary

Fixes the V8 `allocation failure; scavenge might not succeed` crash that hit `pnpm run bench` on the 8192x8192 bigint case (reported after PR #129 merged). The heap hit the 2.56 GB cap with 2.56 GB still live after a full Mark-Compact — meaning GC could not free the previous iteration's matrix when the next iteration tried to allocate.

## Root cause

The hook order inside `beforeEach`:

```ts
beforeEach: () => {
  mat = [];               // drops reference to OLD matrix
  mat = gen(N, N, …);     // ← evaluates BEFORE the gc could run
}
```

When `gen(...)` evaluates, the old matrix is unreferenced but **not yet collected** — and `gen` incrementally allocates the new ~1.6 GB bigint matrix on top of the still-resident old one. Peak: **2 × 1.6 GB = 3.2 GB**, blowing the 2.56 GB cap.

The matching `afterEach` only called `sweep()` (gc), but `mat` was still pointing at the matrix that had just been measured — so gc had nothing to reclaim.

## Fix

Move the matrix-clearing into `afterEach` so it runs before the **next** iteration's allocation:

```ts
beforeEach: () => { mat = gen(N, N, …); }
afterEach: () => { mat = []; sweep(); }
```

Per-iteration peak drops to **one** matrix (~1.6 GB), comfortably fitting the existing 2.56 GB heap cap. The transition state between iterations holds zero matrices instead of two.

## Why not just bump the heap cap

Considered, but the OOM was symptomatic of a real bug (two matrices coexisting), not a fundamental memory requirement. Bumping `--max-old-space-size` to 8 GB would have masked the issue, increased the working set 3x for no benefit on smaller benches, and left the same hazard in place if a future change extended to larger N.

## What `ci.bench.ts` did right (already)

`ci.bench.ts` was already using this pattern correctly (`mat = []; sweep()` in afterEach). The bug was specific to `munkres.bench.ts`.

## Test plan

- [x] `pnpm run lint`: clean
- [x] The order of operations is now: prior iter's afterEach (clear + gc) → next iter's beforeEach (allocate fresh) → task → afterEach. At no point do two matrices coexist.
- [ ] Run `pnpm run bench` to completion locally — the 8192 bigint case should now succeed under the existing 2.56 GB cap.