### PR TITLE
ci(bench): expand to 4 charts, harden workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,6 +6,11 @@ on:
 permissions:
   contents: write
   deployments: write
+# Serialize bench runs so the gh-pages push (force-write of `dev/bench/data.js`)
+# cannot race against itself when two main pushes land in quick succession.
+concurrency:
+  group: benchmark
+  cancel-in-progress: false
 jobs:
   benchmark:
     name: Run benchmarks
@@ -18,21 +23,30 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-          node-version: 24
+          # Pinned to a specific Node 24 patch so V8 updates in newer 24.x
+          # patches cannot drift the baseline without an intentional bump
+          # here. See supported Node.js release schedule at
+          # https://nodejs.org/en/about/releases/
+          node-version: 24.16.0
           cache: "pnpm"
       - name: Clean install
         run: pnpm install --frozen-lockfile
       - name: Run benchmarks
         run: pnpm run bench:ci
       - name: Store results
-        uses: benchmark-action/github-action-benchmark@v1
+        # Pinned to the v1.22.1 commit SHA. Floating `@v1` would let
+        # behavior change underneath us between runs; the SHA is bumped
+        # explicitly when we want the new behavior.
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba
         with:
           name: Munkres Benchmarks
           tool: "customSmallerIsBetter"
           output-file-path: benchmark_results/ci.txt
           github-token: ${{ secrets.BENCHMARK_TOKEN }}
           auto-push: true
+          # Cap chart history; older datapoints are still in `data.js` but
+          # the rendered chart shows only the most recent 100 entries.
+          max-items-in-chart: 100
           # Show alert with commit comment on detecting possible performance regression
           alert-threshold: "150%"
           comment-on-alert: true

--- a/benchmarks/ci.bench.ts
+++ b/benchmarks/ci.bench.ts
@@ -50,11 +50,11 @@ suite.addReporter(new CIReporter(outputPath));
 // Force a synchronous GC between iterations during the measurement phase
 // only. tinybench's `afterEach` runs after the iteration's timing window
 // closes, so the GC pause does not count against the measurement. With
-// per-iteration allocations on the order of 32-96 MB (the bigint matrix
-// dominates), letting GC run on its own schedule across 50+ iterations
-// introduces 2-3× per-iteration noise that swamps the algorithm's
-// intrinsic cost. Forcing GC here pins each iteration to roughly the
-// same heap state and gives the dashboard a stable signal.
+// per-iteration allocations on the order of tens-to-hundreds of MB (the
+// bigint matrix dominates), letting GC run on its own schedule across
+// many iterations introduces 2-3× per-iteration noise that swamps the
+// algorithm's intrinsic cost. Forcing GC here pins each iteration to
+// roughly the same heap state and gives the dashboard a stable signal.
 //
 // Bench-level `setup`/`teardown` gives us the `mode` ('warmup' | 'run'),
 // letting us flip a flag and only sweep during measurement. This is
@@ -72,14 +72,15 @@ const setMode = (_: unknown, mode: "run" | "warmup") => {
 };
 
 // `time: 1000` (tinybench default) lets fast tasks accumulate dense
-// sample counts; the 50-iter floor pins slow tasks. `warmupIterations:
-// 1, warmupTime: 0` keeps warmup to a single priming iteration per
-// task — V8 only needs one to enter the optimized tier, and a
-// non-zero warmup time combined with per-iter GC was the original
-// source of the observed "warmup hangs" (fast tasks would otherwise
-// run millions of warmup iters to fill `warmupTime: 250`).
+// sample counts; the 10-iter floor pins slow tasks (~5-12 sec/iter on a
+// GitHub-hosted runner for the largest sizes). `warmupIterations: 1,
+// warmupTime: 0` keeps warmup to a single priming iteration per task
+// — V8 only needs one to enter the optimized tier, and a non-zero
+// warmup time combined with per-iter GC was the original source of
+// the observed "warmup hangs" (fast tasks would otherwise run millions
+// of warmup iters to fill `warmupTime: 250`).
 const BENCH_OPTS = {
-  iterations: 50,
+  iterations: 10,
   warmup: true,
   warmupIterations: 1,
   warmupTime: 0,
@@ -88,45 +89,42 @@ const BENCH_OPTS = {
   teardown: setMode,
 } as const;
 
-// Create number[][] benchmark
-(() => {
-  const N = 4096; // 2**12
-  let mat: Matrix<number>;
-  bench = new Bench(BENCH_OPTS).add(
-    `number[${N}][${N}]`,
-    () => munkres(mat),
-    {
-      afterEach: () => {
-        mat = [];
-        sweep();
-      },
-      beforeEach: () => {
-        mat = gen(N, N, () => genNum(MIN_VAL, MAX_VAL));
-      },
-    },
-  );
-  suite.add("number[][]", bench);
-})();
+// ---- Number benchmarks ----------------------------------------------------
+//
+// Each task gets its own dashboard chart (the `name` field is keyed
+// per-chart by github-action-benchmark).
 
-// Create bigint[][] benchmark
-(() => {
-  const N = 2048; // 2**11
-  let mat: Matrix<bigint>;
-  bench = new Bench(BENCH_OPTS).add(
-    `bigint[${N}][${N}]`,
-    () => munkres(mat),
-    {
-      afterEach: () => {
-        mat = [];
-        sweep();
-      },
-      beforeEach: () => {
-        mat = gen(N, N, () => genBig(MIN_VAL, MAX_VAL));
-      },
+bench = new Bench(BENCH_OPTS);
+for (const N of [2048, 4096] as const) {
+  let mat: Matrix<number>;
+  bench.add(`number[${N}][${N}]`, () => munkres(mat), {
+    afterEach: () => {
+      mat = [];
+      sweep();
     },
-  );
-  suite.add("bigint[][]", bench);
-})();
+    beforeEach: () => {
+      mat = gen(N, N, () => genNum(MIN_VAL, MAX_VAL));
+    },
+  });
+}
+suite.add("number[][]", bench);
+
+// ---- Bigint benchmarks ----------------------------------------------------
+
+bench = new Bench(BENCH_OPTS);
+for (const N of [2048, 4096] as const) {
+  let mat: Matrix<bigint>;
+  bench.add(`bigint[${N}][${N}]`, () => munkres(mat), {
+    afterEach: () => {
+      mat = [];
+      sweep();
+    },
+    beforeEach: () => {
+      mat = gen(N, N, () => genBig(MIN_VAL, MAX_VAL));
+    },
+  });
+}
+suite.add("bigint[][]", bench);
 
 // Run benchmarks and report results
 await suite.run();


### PR DESCRIPTION
## Summary

Tier 1 + 2 dashboard improvements from the post-release review:
- **Tier 1 (workflow hardening)** — concurrency, version pinning, chart-history cap
- **Tier 2 (more visibility)** — expand from 2 to 4 dashboard charts

No source code touched.

## Workflow changes

| Change | Why |
|---|---|
| Add `concurrency: { group: benchmark, cancel-in-progress: false }` | Two main pushes in quick succession could otherwise race on the `gh-pages` push (the action force-writes `dev/bench/data.js`) |
| Pin Node `24` → `24.16.0` | V8 updates within 24.x can drift the baseline without any source change |
| Pin action `@v1` → `@52576c9...` (v1.22.1 SHA) | Behavior changes in the action become explicit bumps rather than silent drifts |
| Add `max-items-in-chart: 100` | data.js has ~130 entries; chart now caps rendering at 100, trimming visual noise |

The 150%-of-baseline alert threshold and `fail-on-alert: true` unchanged: this is what caught the PR #119 bigint regression.

## Bench script changes

Expand dashboard coverage from 2 charts to 4:

```
number[2048][2048]  (new)
number[4096][4096]  (existing)
bigint[2048][2048]  (existing)
bigint[4096][4096]  (new)
```

Each task gets its own dashboard chart, with independent y-axis and independent regression-alert tracking. The two new sizes give visibility into how perf scales between 2k and 4k for each type — a single-point view hides O(N³) scaling drift that would only show up at the other size.

Unified iteration floor at **10 samples** (was 50 for the existing two benches). With `time: 1000` retained as the upper bound, fast tasks still accumulate dense samples until time fills; slow tasks like bigint 4096 (~6 sec/iter) hit the floor at exactly 10. RME comes in at 5-7% across all four benches.

## Local smoke run

```
number[2048][2048] x  249 ms ±4.84% (10 samples)
number[4096][4096] x 1185 ms ±5.27% (10 samples)
bigint[2048][2048] x 1228 ms ±7.38% (10 samples)
bigint[4096][4096] x 6290 ms ±6.76% (10 samples)
```

Total ~3.5 min local; **~6-8 min on GHA-hosted runner** (well under any job limit). Current production runs take ~3 min, so this roughly doubles bench wall time in exchange for 2× the data points.

## Dashboard impact

The two new charts (`number[2048][2048]`, `bigint[4096][4096]`) will appear empty until the first run on main lands. The existing two charts continue accumulating with their full history (subject to the new 100-item display cap).

## Test plan

- [x] `pnpm run lint`: clean
- [x] `pnpm exec tsc --noEmit`: clean
- [x] Local `pnpm run bench:ci`: all 4 tasks complete, JSON output well-formed
- [ ] After merge: first benchmark.yml run on main produces 4 entries with finite values and sample counts

## Not in this PR

PR-time benchmark comparison (Tier 3 from the review) is deferred — needs careful tuning to avoid noisy false-positive PR comments under GHA-hosted runner variance.