### PR TITLE
ci(bench): add release-only dashboard via tag trigger

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,13 +1,21 @@
 name: Benchmark
 on:
   push:
+    # Every push to main feeds the per-commit dashboard (dev/bench) for
+    # between-release regression detection. Every release tag additionally
+    # feeds a separate release-only dashboard (release/bench) for a clean
+    # release-over-release trend. The data-dir-path is chosen per-ref in
+    # the "Store results" step below.
     branches: [main]
+    tags: ["v*"]
   workflow_dispatch:
 permissions:
   contents: write
   deployments: write
-# Serialize bench runs so the gh-pages push (force-write of `dev/bench/data.js`)
-# cannot race against itself when two main pushes land in quick succession.
+# Serialize bench runs so the gh-pages push (force-write of the dashboard's
+# data.js) cannot race against itself. This matters most at release time,
+# when the main-branch push and the tag push fire within seconds of each
+# other — they share this group and run one after the other.
 concurrency:
   group: benchmark
   cancel-in-progress: false
@@ -44,10 +52,20 @@ jobs:
           output-file-path: benchmark_results/ci.txt
           github-token: ${{ secrets.BENCHMARK_TOKEN }}
           auto-push: true
+          # Tag pushes write to a separate release-only dashboard; every
+          # other push (main, manual) writes to the per-commit dashboard.
+          # The two are independent data.js files under gh-pages, so they
+          # render as separate pages:
+          #   /dev/bench     — per-commit, regression detection
+          #   /release/bench — release-over-release trend
+          benchmark-data-dir-path: ${{ startsWith(github.ref, 'refs/tags/') && 'release/bench' || 'dev/bench' }}
           # Cap chart history; older datapoints are still in `data.js` but
           # the rendered chart shows only the most recent 100 entries.
+          # (Releases are rare, so this never evicts a release point.)
           max-items-in-chart: 100
-          # Show alert with commit comment on detecting possible performance regression
+          # Alert on a >150% slowdown vs the previous datapoint. On the
+          # per-commit dashboard that compares against the prior commit;
+          # on the release dashboard, against the prior release.
           alert-threshold: "150%"
           comment-on-alert: true
           fail-on-alert: true


### PR DESCRIPTION
## Summary

Adds a second benchmark dashboard that shows **release-over-release** trend, without removing the per-commit dashboard that catches between-release regressions.

The per-commit dashboard (`/dev/bench`) accumulates a point per merge to main — great for regression detection (it surfaced the PR #119 bigint slowdown), but noisy for reading release-to-release trend, and its 100-item display cap will eventually evict old releases. This adds `/release/bench` alongside it.

## How it works

- The benchmark workflow now also triggers on `push: tags: ['v*']` (in addition to main pushes + manual dispatch).
- `benchmark-data-dir-path` is selected per-ref:
  ```yaml
  benchmark-data-dir-path: ${{ startsWith(github.ref, 'refs/tags/') && 'release/bench' || 'dev/bench' }}
  ```
  Tag pushes → `release/bench`; everything else → `dev/bench`. Two independent `data.js` files on gh-pages → two separate pages.
- The shared `concurrency: benchmark` group serializes the main-push and tag-push runs that fire within seconds of each other at release time, avoiding a gh-pages race.
- On the release dashboard, the existing 150% alert compares each release against the **prior release** — a built-in release-over-release regression gate.

## Backfill (already done, directly on gh-pages)

The 5 historical releases are already live at `/release/bench`, backfilled from the **already-recorded** `dev/bench` numbers (each release tag points at a commit that was benchmarked on its main-push, so these are the real recorded values, not re-runs on today's runners):

| Release | number[4096][4096] | bigint[2048][2048] |
|---|---:|---:|
| v2.0.2 | 2072.7 ms | 1421.7 ms |
| v2.0.3 | 2072.5 ms | 1390.4 ms |
| v2.0.4 | 2000.6 ms | 1389.5 ms |
| v2.0.5 | 1630.0 ms | 1303.1 ms |
| v2.1.0 | 1132.2 ms | 1358.0 ms |

The number path's steady improvement across releases is now visible at a glance. (gh-pages commit `4adb120`, additive — `dev/bench` untouched.)

## Note on chart continuity

The 5 backfilled points use the 2-bench layout that was in effect through v2.1.0 (`number[4096][4096]`, `bigint[2048][2048]`). From v2.1.1 onward, tag runs emit the 4-bench layout from PR #133 (`number[2048]`/`[4096]`, `bigint[2048]`/`[4096]`). So:
- `number[4096][4096]` and `bigint[2048][2048]` charts → continuous from v2.0.2
- `number[2048][2048]` and `bigint[4096][4096]` charts → start at v2.1.1

This is expected and self-explanatory on the dashboard.

## Test plan

- [x] Workflow YAML structurally valid; per-ref expression resolves to `release/bench` on tag, `dev/bench` otherwise
- [x] `/release/bench/data.js` validates (5 entries, chronological, correct shape) — pushed to gh-pages
- [ ] First post-merge release tag appends a 6th point to `/release/bench` (verifiable at next release)

No source or published-package changes.