### PR TITLE
ci(bench): label release datapoints by tag

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -69,3 +69,56 @@ jobs:
           alert-threshold: "150%"
           comment-on-alert: true
           fail-on-alert: true
+
+      # The benchmark action records each datapoint by commit SHA + message,
+      # with no knowledge of the tag. On a tag push, stamp the just-appended
+      # release/bench entry with its tag (e.g. "v2.1.0") so the dashboard
+      # labels points by release rather than SHA. The release/bench
+      # index.html renders `tag || sha`, so this is purely additive — an
+      # unstamped point still shows its SHA.
+      - name: Label release datapoint by tag
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ secrets.BENCHMARK_TOKEN }}
+        run: |
+          set -euo pipefail
+          work="$(mktemp -d)"
+          git clone --branch gh-pages --depth 1 \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$work"
+          cd "$work"
+          node - <<'NODE'
+          const fs = require("fs");
+          const file = "release/bench/data.js";
+          const raw = fs.readFileSync(file, "utf8");
+          // Strip the `window.BENCHMARK_DATA = ` assignment wrapper (and any
+          // trailing `;`) to recover the JSON the action wrote.
+          const data = JSON.parse(raw.replace(/^[^=]*=\s*/, "").replace(/;\s*$/, ""));
+          const tag = process.env.RELEASE_TAG;
+          const sha = process.env.RELEASE_SHA;
+          let changed = 0;
+          for (const list of Object.values(data.entries)) {
+            for (const e of list) {
+              if (e.commit.id === sha && e.tag !== tag) {
+                e.tag = tag;
+                ++changed;
+              }
+            }
+          }
+          if (changed > 0) {
+            // Re-emit in the action's exact format (pretty JSON, no trailing
+            // semicolon/newline) so the diff is just the added `tag` field.
+            fs.writeFileSync(file, "window.BENCHMARK_DATA = " + JSON.stringify(data, null, 2));
+          }
+          console.log(`tagged ${changed} entry/entries as ${tag}`);
+          NODE
+          if git diff --quiet; then
+            echo "No change (entry already tagged, or not yet present)."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add release/bench/data.js
+            git commit -m "Label release datapoint ${RELEASE_SHA} as ${RELEASE_TAG}"
+            git push origin gh-pages
+          fi


### PR DESCRIPTION
## Summary

Follow-up to the release dashboard (the tag-trigger merged in #140). Makes the release dashboard label its x-axis by **tag** (`v2.1.0`) instead of 7-char commit SHA.

## Why a workflow step is needed

The benchmark action records each datapoint by commit SHA + message — it has no knowledge of the git tag. So without help, the release dashboard's x-axis shows meaningless SHAs. This step injects the tag.

## What's already done (directly on gh-pages, additive)

- The 5 historical release points were backfilled with their `tag` field (`v2.0.2` … `v2.1.0`).
- `release/bench/index.html` now renders `d.tag || d.commit.id.slice(0, 7)` on the axis, titles the axis "release", and leads the tooltip with the tag.

Both are live: https://havelessbemore.github.io/munkres/release/bench/

## What this PR adds

A `Label release datapoint by tag` step in `benchmark.yml`, gated on `startsWith(github.ref, 'refs/tags/')`, that runs **after** the benchmark action appends the release point:

1. Fresh shallow clone of `gh-pages` (the action has already pushed its datapoint by the time this runs).
2. Node script finds the entry whose `commit.id === github.sha` and sets `tag = github.ref_name`, re-emitting `data.js` in the action's exact format (pretty JSON, no trailing semicolon) → the diff is just the added field.
3. Idempotent: if the entry is already tagged (or not yet present), no change → `git diff --quiet` skips the commit/push.

Because `index.html` renders `tag || sha`, this is purely additive — an unstamped point still shows its SHA, so nothing breaks if the step is ever skipped.

## Verification

Tested the embedded script against a fixture in the action's `data.js` format:
- tags the new SHA's entry ✓
- preserves an existing entry's tag ✓
- re-run reports 0 changes (idempotent → no spurious gh-pages commit) ✓

First real exercise will be the next release tag, which should append a 6th release point already labeled.

## Note

PR #140's branch was auto-deleted on merge; this is a clean branch off current main with just the post-step commit. (Also tidied: deleted the orphaned recreated branch.)