### PR TITLE
docs: rewrite README for consumers; move dev sections to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,11 +13,30 @@ This project is governed by the [Code of Conduct](./CODE_OF_CONDUCT.md). By cont
 
 ## Developing
 
+This project uses [pnpm](https://pnpm.io/). Clone and install:
+
+```bash
+git clone git@github.com:havelessbemore/munkres.git
+cd munkres
+pnpm install
+```
+
+Common tasks:
+
 - `pnpm run test`: Run tests
-- `pnpm run test:coverage`: Create coverage reports
+- `pnpm run test:coverage`: Create a coverage report (output in `./coverage/index.html`)
 - `pnpm run lint`: Check styleguide adherence
-- `pnpm run format`: Automatically adjust your code to the styleguide.
-- `pnpm run build`: Build the source
+- `pnpm run format`: Automatically adjust your code to the styleguide
+- `pnpm run build`: Build the source, emitting ESM (`.mjs`) and CommonJS (`.cjs`) modules to `dist/`
+
+### Benchmarks
+
+```bash
+pnpm run bench      # full local suite (all matrix sizes)
+pnpm run bench:ci   # the subset run in CI, written to benchmark_results/
+```
+
+Benchmarks run automatically on every commit to `main` (per-commit dashboard) and on every release tag (release-over-release dashboard). Both are published under [havelessbemore.github.io/munkres](https://havelessbemore.github.io/munkres/dev/bench/). The harness forces a GC between iterations (`--expose-gc`) and uses a seeded PRNG so results are comparable run-to-run; treat the dashboards as relative regression signals rather than absolute algorithm speed.
 
 ### Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -1,320 +1,134 @@
 # Munkres
 
-A lightweight and efficient implementation of the [Munkres (Hungarian) algorithm](https://en.wikipedia.org/wiki/Hungarian_algorithm) for optimal assignment.
+Optimally pair up two sets (workers to jobs, drivers to riders, bids to items) to minimize total cost.
+
+Given a cost matrix where `matrix[y][x]` is the cost of pairing item `y` with item `x`, `munkres` returns the one-to-one assignment with the lowest possible total cost. It's a fast, dependency-free implementation of the [Munkres (Hungarian) algorithm](https://en.wikipedia.org/wiki/Hungarian_algorithm).
+
+Reach for it whenever you have a table of pairing costs (or profits) and need the *optimal* matching rather than a greedy guess.
 
 [![Version](https://img.shields.io/npm/v/munkres.svg)](https://www.npmjs.com/package/munkres)
 [![JSR](https://jsr.io/badges/@munkres/munkres)](https://jsr.io/@munkres/munkres)
-[![Maintenance](https://img.shields.io/maintenance/yes/2026.svg)](https://github.com/havelessbemore/munkres/graphs/commit-activity)
-[![License](https://img.shields.io/github/license/havelessbemore/munkres.svg)](https://github.com/havelessbemore/munkres/blob/master/LICENSE)
+[![License](https://img.shields.io/github/license/havelessbemore/munkres.svg)](https://github.com/havelessbemore/munkres/blob/main/LICENSE)
 [![codecov](https://codecov.io/gh/havelessbemore/munkres/graph/badge.svg?token=F362G7C9U0)](https://codecov.io/gh/havelessbemore/munkres)
 ![npm bundle size](https://img.shields.io/bundlephobia/minzip/munkres)
 
 ## Features
 
-1. Flexible
+- **Flexible:** `number` or `bigint` costs; square (_NxN_) or rectangular (_MxN_) matrices; any [`MatrixLike`](src/types/matrixLike.ts) input (arrays, typed arrays, custom indexables).
+- **Fast:** _O(M²N)_ time when _M ≤ N_ (_O(MN²)_ otherwise) and only _O(M + N)_ extra memory. [Benchmarks below](#benchmarks).
+- **Typed & dependency-free:** first-class TypeScript types, zero runtime dependencies, ships both ESM and CommonJS.
+- **Robust:** mark forbidden assignments with `Infinity`; built-in [helpers](#helpers) for building and transforming matrices.
 
-   - Use `number` or `bigint` matrices.
-   - Use square (_NxN_) or rectangular (_MxN_) matrices.
-   - Works with any [MatrixLike](src/types/matrixLike.ts) input. Use arrays, typed arrays, custom objects, etc.
-
-1. Fast ([benchmarks](#results))
-
-   - _O(M<sup>2</sup>N)_ when _M <= N_
-
-   - _O(MN<sup>2</sup>)_ when _M > N_
-
-1. Efficient
-
-   - _O(M + N)_ memory
-
-1. Robust
-   - Supports `-Infinity` and `Infinity` values.
-   - [Helper methods](#helpers) provided for creating and modifying matrices.
-
-## Getting Started
-
-### Install
-
-NPM:
+## Install
 
 ```bash
 npm install munkres
-```
 
-Yarn:
-
-```bash
 yarn add munkres
-```
 
-JSR:
+pnpm add munkres
 
-```bash
 jsr add @munkres/munkres
 ```
 
 ## Usage
 
-With a cost matrix:
-
 ```javascript
-import munkres from "munkres";
+import { munkres } from "munkres";
 
-// Create a cost matrix. Cell [y, x] is the cost
-// of assigning the y-th worker to the x-th job.
+// matrix[y][x] = cost of assigning worker y to job x
 const costMatrix = [
   [1, 2, 3],
   [2, 4, 6],
   [3, 6, 9],
 ];
 
-// Find a set of optimal assignments pairs (y, x).
 const assignments = munkres(costMatrix);
-
-console.log(assignments);
-// Output: [[0, 2], [1, 1], [2, 0]]
+// → [[0, 2], [1, 1], [2, 0]]   (worker 0 → job 2, worker 1 → job 1, worker 2 → job 0)
 ```
 
-With a profit matrix:
+Each result is a `[y, x]` pair (row, then column). The result has `min(rows, cols)` pairs; if there are more workers than jobs (or vice versa), the unmatched ones are simply absent.
+
+**Maximizing instead of minimizing?** Convert your profit matrix to a cost matrix first:
 
 ```javascript
 import { munkres, copyMatrix, invertMatrix } from "munkres";
 
-// Create a profit matrix. Cell [y, x] is the
-// profit of assigning the y-th worker to the x-th job.
 const profitMatrix = [
   [9, 8, 7],
   [8, 6, 4],
   [7, 4, 1],
 ];
 
-// Covert the profit matrix into a cost matrix.
 const costMatrix = copyMatrix(profitMatrix);
-invertMatrix(costMatrix);
-
-// Find a set of optimal assignments pairs (y, x).
+invertMatrix(costMatrix); // flip profits into costs
 const assignments = munkres(costMatrix);
-
-console.log(assignments);
-// Output: [[0, 2], [1, 1], [2, 0]]
-```
-
-Skipping input validation on large guaranteed-finite matrices:
-
-```javascript
-import { munkres } from "munkres";
-
-// When you know the matrix contains no Infinity or NaN, `{ finite: true }`
-// skips the O(Y*X) validation scan and dispatches straight to the
-// all-finite arithmetic path. Faster for large matrices.
-const assignments = munkres(largeFiniteCostMatrix, { finite: true });
+// → [[0, 2], [1, 1], [2, 0]]
 ```
 
 ## API
 
-- `munkres(costMatrix, options?)`
+### `munkres(costMatrix, options?)`
 
-  Executes the Munkres algorithm on the given cost matrix and returns a set of optimal assignment pairs. Even if there are multiple optimal assignment sets, only one is returned.
+Runs the algorithm and returns a set of optimal `[y, x]` assignment pairs. If several optimal assignments exist, one is returned.
 
-  **Parameters**
+- **`costMatrix`**: a `MatrixLike<number>` or `MatrixLike<bigint>` where `costMatrix[y][x]` is the cost of assigning worker `y` to job `x`. Use `Infinity` / `-Infinity` to forbid an assignment.
+- **`options.finite`** _(boolean, default `false`)_: promise the matrix is all-finite and in-range, skipping input validation for a small speedup on large matrices. If the promise is broken, the result is undefined (it won't throw). See [`MunkresOptions`](src/munkres.options.ts).
 
-  - `costMatrix`: a `MatrixLike<number>` or `MatrixLike<bigint>` where `costMatrix[y][x]` is the cost of assigning worker `y` to job `x`. Use `Infinity` / `-Infinity` to mark forbidden assignments. The matrix is treated as `costMatrix.length` × `costMatrix[0].length`; cells beyond row 0's width are ignored.
-  - `options` (optional):
-    - `finite: boolean` — when `true`, promises that the matrix contains no `NaN` or `Infinity` **and** that its range is in-bounds (`max(c) - min(c) <= Number.MAX_VALUE / 2`). Skips both the finiteness scan and the range check, dispatching straight to the fast all-finite path. If either promise is violated, the result is undefined (may produce a wrong assignment or `Infinity` / `NaN` cells; never throws `RangeError` / `TypeError` from this path).
+**Returns** `Pair<number>[]`, an array of `[y, x]` pairs, length `min(rows, cols)`.
 
-  **Returns**
+**Throws**
 
-  An array of `[y, x]` pairs. The result length is `min(rows, cols)` and pairs are always `[y, x]` (row, column) regardless of shape. When `rows > cols`, the unmatched rows are simply absent from the result; when `cols > rows`, the unmatched columns are absent.
+- `TypeError`: a `number` matrix contains `NaN`. (Use `Infinity` to forbid an assignment instead.)
+- `RangeError`: a `number` matrix's value range (`max - min`) exceeds `Number.MAX_VALUE / 2` and could overflow. Scale the matrix down, or use `bigint`.
 
-  **Throws**
-
-  - `TypeError`: if a `number` cost matrix contains `NaN`. The error message includes the coordinates of the first NaN encountered. Use `Infinity` for forbidden assignments instead. Skipped under `{ finite: true }`.
-  - `RangeError`: if a `number` cost matrix has `max(c) - min(c) > Number.MAX_VALUE / 2`. The algorithm's worst-case intermediate arithmetic magnitude is `2 * (max - min)`; this guard keeps all intermediates representable in IEEE-754 double precision. Scale your matrix down, or use a `bigint` matrix. Skipped under `{ finite: true }`. `bigint` matrices are exempt entirely. The check applies **only to all-finite matrices** — a `number` matrix containing `Infinity` / `-Infinity` routes to the Infinity-handling path before the range check and is never range-checked (forbidden cells are saturated, not summed, so they cannot overflow the same way).
-
-  **Numeric precision**
-
-  The `number` path uses IEEE 754 double-precision arithmetic. For matrices of *integer* costs where exact optima are required (especially when values approach or exceed `Number.MAX_SAFE_INTEGER`), pass a `bigint` cost matrix to use the arbitrary-precision path. Floating-point inputs are inherently approximate; the `number` path may return a valid but suboptimal assignment when precision is lost in slack comparisons.
+> **Precision:** the `number` path uses 64-bit floats. For integer costs that need an exact optimum (especially near or beyond `Number.MAX_SAFE_INTEGER`), use a `bigint` matrix for arbitrary precision.
 
 ### Types
 
-- [`Matrix<T>`](src/types/matrix.ts): A generic 2D matrix (i.e. `T[][]`).
-
-- [`MatrixLike<T>`](src/types/matrixLike.ts): A generic read-only 2D matrix.
-
-  - Can be made from any `ArrayLike` objects (i.e. any indexable object with a numeric `length` property). This
-    allows for more flexibility, such as matrices made with typed arrays or objects.
-
-- [`Pair<A, B = A>`](src/types/pair.ts): A generic pair (i.e. `[A, B]`).
+- [`Matrix<T>`](src/types/matrix.ts): a 2D matrix, `T[][]`.
+- [`MatrixLike<T>`](src/types/matrixLike.ts): a read-only 2D matrix accepting any `ArrayLike` (arrays, typed arrays, custom indexables).
+- [`Pair<A, B = A>`](src/types/pair.ts): a `[A, B]` tuple.
+- [`MunkresOptions`](src/munkres.options.ts): the options object for `munkres()`.
 
 ### Helpers
 
-1. `copyMatrix(matrix)`: Creates a copy of the given matrix.
+Utilities for building and transforming cost matrices:
 
-1. `createMatrix(workers, jobs, callbackFn)`: Generates a matrix based on the given workers, jobs, and callback function.
-
-1. `genMatrix(numRows, numCols, callbackFn)`: Generates a matrix based on the given dimensions and a callback function.
-
-1. `getMatrixMax(matrix)`: Finds the maximum value in a given matrix.
-
-1. `getMatrixMin(matrix)`: Finds the minimum value in a given matrix.
-
-1. `invertMatrix(matrix, bigVal?)`: Inverts the values in the given matrix. Useful for converting between minimizing and maximizing problems. If `bigVal` is not given, the matrix's max value is used instead.
-
-1. `negateMatrix(matrix)`: Negates all values in the given matrix. Useful for converting between minimizing and maximizing problems.
-
-## Community and Support
-
-Contributions are welcome!
-
-- **Questions / Dicussions**: Please contact us via [GitHub discussions](https://github.com/havelessbemore/munkres/discussions).
-
-- **Bug Reports**: Please use the [GitHub issue tracker](https://github.com/havelessbemore/munkres/issues) to report any bugs. Include a detailed description and any relevant code snippets or logs.
-
-- **Feature Requests**: Please submit feature requests as issues, clearly describing the feature and its potential benefits.
-
-- **Pull Requests**: Please ensure your code adheres to the existing style of the project and include any necessary tests and documentation.
-
-For more information, check out the [contributor's guide](https://github.com/havelessbemore/munkres/CONTRIBUTING.md).
-
-## Build
-
-1. Clone the project from github
-
-```bash
-git clone git@github.com:havelessbemore/munkres.git
-cd munkres
-```
-
-2. Install dependencies (this project uses [pnpm](https://pnpm.io/))
-
-```bash
-pnpm install
-```
-
-3. Build the project
-
-```bash
-pnpm run build
-```
-
-This will output ECMAScript (`.mjs`) and CommonJS (`.js`) modules in the `dist/` directory.
-
-## Format
-
-To run the code linter:
-
-```bash
-pnpm run lint
-```
-
-To automatically fix linting issues, run:
-
-```bash
-pnpm run format
-```
-
-## Test
-
-To run tests:
-
-```bash
-pnpm test
-```
-
-To run tests with a coverage report:
-
-```bash
-pnpm run test:coverage
-```
-
-A coverage report is generated at `./coverage/index.html`.
+| Helper | Description |
+| --- | --- |
+| `copyMatrix(matrix)` | Copy a matrix. |
+| `createMatrix(workers, jobs, callbackFn)` | Build a matrix from worker/job lists and a cost function. |
+| `genMatrix(numRows, numCols, callbackFn)` | Build a matrix from dimensions and a callback. |
+| `getMatrixMax(matrix)` / `getMatrixMin(matrix)` | Find the max / min value. |
+| `invertMatrix(matrix, bigVal?)` | Invert values (max → min); converts between minimizing and maximizing. Uses the matrix max if `bigVal` is omitted. |
+| `negateMatrix(matrix)` | Negate all values; another way to swap minimizing and maximizing. |
 
 ## Benchmarks
 
-[Run benchmarks in your browser](https://jsbm.dev/QHoz2G2XHQknL).
+Performance is tracked automatically on every release and every commit to `main`:
 
-To run locally:
+- **[Release-over-release trend →](https://havelessbemore.github.io/munkres/release/bench/)**: how performance changes across published versions.
+- **[Per-commit history →](https://havelessbemore.github.io/munkres/dev/bench/)**: fine-grained regression tracking.
+- **[Run it in your browser →](https://jsbm.dev/QHoz2G2XHQknL)**: try it on your own inputs.
+- **[Run locally →](CONTRIBUTING.md#benchmarks)**: See the contributing guide.
 
-```bash
-pnpm run bench
-```
+As a ballpark (Apple M2, v2.1.0):
+| Matrix Size | `number` | `bigint` |
+| --- | --- | --- |
+| 64x64 | ~0.1ms | ~0.26ms |
+| 256x256 | ~2ms | ~8ms |
+| 1024x1024 | ~40ms | ~222ms |
+| 4096x4096 | ~1s | ~5.7s |
 
-### CI / CD
+## Contributing
 
-Benchmarks are integrated into our CI/CD pipeline and automatically run with each commit to the `main` branch. This helps monitor the performance impacts of development, preventing regressions and verifying changes maintain performance standards.
+Contributions are welcome. See the [contributing guide](CONTRIBUTING.md) for local setup, tests, and the style guide.
 
-[View historical results](https://havelessbemore.github.io/munkres/dev/bench/).
+- **Questions / discussion:** [GitHub Discussions](https://github.com/havelessbemore/munkres/discussions)
+- **Bugs:** [Issue tracker](https://github.com/havelessbemore/munkres/issues)
+- **Feature requests:** open an issue describing the feature and its benefit.
 
-Specs:
+## License
 
-- Package version: latest
-- Runtime: NodeJS v24
-- Benchmarking Tool: tinybench v6
-- OS: [ubuntu-latest](https://github.com/actions/runner-images)
-
-#### What the dashboard measures
-
-Each datapoint is **per-iteration wall time**, averaged across 50 iterations after a warmup pass. Per-iteration cost is dominated by the bench harness itself for large inputs:
-
-- The benchmark generates a fresh cost matrix on every iteration (`beforeEach`), runs `munkres()` (the timed window), then clears it (`afterEach`). Tinybench measures only the `munkres()` call, but the allocator/GC state at the start of each iteration is shaped by what happened across the surrounding 50 iterations.
-- For `bigint[2048][2048]`, the input matrix alone is ~96 MB of boxed BigInts. The algorithm itself completes in ~800 ms (measurable via a one-shot timed call). The dashboard reports ~3 s under the same conditions — the additional ~2 s is per-iteration allocator/GC overhead that compounds across the run.
-- For `number[4096][4096]`, the matrix is ~32 MB of doubles (smaller, denser, often SMI-optimized by V8), so the harness overhead is a smaller share.
-
-To stabilize the per-iteration signal, the bench scripts force a synchronous GC between iterations (via `globalThis.gc()`, enabled by `--expose-gc`). This pins each iteration to a comparable heap state and reduces run-to-run variance on shared CI runners. The forced GC happens inside `afterEach`, after the timing window has already closed, so it does not bias the measurement.
-
-**Use the dashboard for relative regression detection across commits, not as a measure of algorithm speed in isolation.**
-
-### Results
-
-Below are the latest results from running locally.
-
-Specs:
-
-- Package version: v2.1.0
-- Runtime: NodeJS v24.16.0
-- Benchmarking Tool: tinybench v6
-- Machine:
-  - Model: MacBook Air
-  - Chip: Apple M2
-  - Memory: 8 GB
-  - OS: MacOS Sonoma
-
-#### `number[][]`
-
-| Dimensions | Min (ms)    | Max (ms)    | Avg (ms)    | Samples   |
-| ---------- | ----------- | ----------- | ----------- | --------- |
-| 2x2        | 0.00021     | 0.503       | 0.00039     | 2,573,155 |
-| 4x4        | 0.00042     | 31.00483    | 0.0008      | 1,251,128 |
-| 8x8        | 0.00117     | 0.28258     | 0.00202     | 494,056   |
-| 16x16      | 0.00346     | 0.44662     | 0.00665     | 150,479   |
-| 32x32      | 0.01438     | 0.72733     | 0.0249      | 40,160    |
-| 64x64      | 0.06171     | 0.47958     | 0.09565     | 10,456    |
-| 128x128    | 0.27154     | 0.91971     | 0.39716     | 2,518     |
-| 256x256    | 1.32696     | 2.43667     | 1.82393     | 549       |
-| 512x512    | 6.31804     | 10.00113    | 8.1618      | 123       |
-| 1024x1024  | 32.75533    | 41.28104    | 37.98536    | 27        |
-| 2048x2048  | 171.33817   | 230.52771   | 205.5992    | 10        |
-| 4096x4096  | 945.21004   | 1,150.39442 | 1,024.3369  | 10        |
-| 8192x8192  | 5,286.44342 | 5,782.38804 | 5,517.78106 | 10        |
-
-#### `bigint[][]`
-
-| Dimensions | Min (ms)     | Max (ms)     | Avg (ms)     | Samples   |
-| ---------- | ------------ | ------------ | ------------ | --------- |
-| 2x2        | 0.00017      | 1.26404      | 0.00034      | 2,944,075 |
-| 4x4        | 0.0005       | 23.07121     | 0.00095      | 1,048,286 |
-| 8x8        | 0.00183      | 0.70287      | 0.00367      | 272,834   |
-| 16x16      | 0.00662      | 0.79025      | 0.01451      | 68,924    |
-| 32x32      | 0.03004      | 0.932        | 0.06064      | 16,491    |
-| 64x64      | 0.15421      | 1.08596      | 0.26307      | 3,802     |
-| 128x128    | 0.79779      | 2.43008      | 1.19253      | 839       |
-| 256x256    | 5.12621      | 17.79483     | 7.6404       | 131       |
-| 512x512    | 37.69554     | 51.83492     | 43.68971     | 23        |
-| 1024x1024  | 204.64667    | 254.14863    | 222.2071     | 10        |
-| 2048x2048  | 1,000.31754  | 1,344.90021  | 1,107.35987  | 10        |
-| 4096x4096  | 5,124.11313  | 6,414.79167  | 5,700.34545  | 10        |
-| 8192x8192  | 28,033.31425 | 34,693.91021 | 31,153.56253 | 10        |
-
----
-
-Made with ❤️ by [Michael Rojas](https://github.com/havelessbemore)
+[MIT](LICENSE) © [Michael Rojas](https://github.com/havelessbemore)


### PR DESCRIPTION
## Summary

Refocuses the README on the consumer (someone deciding whether to adopt the package, then using it) and moves contributor-only material into the already-existing `CONTRIBUTING.md`. Also wires in the new release-over-release benchmark dashboard. 321 lines down to ~130.

The README had drifted into a maintainer's lab notebook: Big-O notation in the first screen, a six-sentence `RangeError` derivation, a four-paragraph GC/allocator explainer, two stale 13-row local benchmark tables, and full clone/build/test/format instructions. None of that helps someone running `npm install munkres`.

I got an independent fresh-eyes consumer critique to pressure-test the changes; its top findings (value-prop does not land, dev sections bloat the doc, the benchmark explainer and tables are noise) drove the rewrite.

## README changes

- **Value proposition up top.** Opens with "Optimally pair up two sets (workers to jobs, drivers to riders, bids to items) to minimize total cost," plus a one-line "reach for it when," instead of the bare "implementation of the Munkres algorithm."
- **Features as scannable bullets.** Big-O demoted to one line; surfaced the real buying signals (first-class TS types, zero dependencies, ESM + CJS).
- **Usage tightened.** Keeps the basic and profit-matrix examples; drops the `{ finite: true }` snippet (a perf knob, not a getting-started step, still documented under API). Adds a one-line note on the result shape.
- **API condensed.** The `Throws` block goes from multi-paragraph derivations to one line each; the full reasoning already lives in the JSDoc / type definitions, which are linked.
- **Benchmarks rewired** (the "use the new benchmark" ask):
  - [Release-over-release dashboard](https://havelessbemore.github.io/munkres/release/bench/) (primary)
  - [Per-commit dashboard](https://havelessbemore.github.io/munkres/dev/bench/)
  - [In-browser playground](https://jsbm.dev/QHoz2G2XHQknL)
  - a compact 4-row ballpark table, replacing the two stale 13-row tables and the GC explainer.
- **Dropped** the year-pinned maintenance badge; **added** a License line.
- **No em dashes** in prose (commas, colons, parentheses instead).

## CONTRIBUTING.md changes

- Absorbed the clone + install + build/output steps and the local benchmark commands (`pnpm run bench`, `bench:ci`) into the existing **Developing** section, so nothing is lost; the README links here instead of duplicating it.
- Corrected a stale detail the old README carried: the CommonJS build output is `.cjs`, not `.js`.

## Verification

- [x] Helper signatures in the new API table checked against `src/helpers.ts`
- [x] Internal anchors (`#benchmarks`, `#helpers`) and `CONTRIBUTING.md#benchmarks` resolve
- [x] Usage examples match `examples/src/basic/*` (named `munkres` import, correct output)
- [x] Ballpark table numbers consistent with the recorded v2.1.0 local results
- [x] No em dashes in README or CONTRIBUTING

No code or published-package changes.