### PR TITLE
docs: correct Infinity assignment semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Reach for it whenever you have a table of pairing costs (or profits) and need th
 - **Flexible:** `number` or `bigint` costs; square (_NxN_) or rectangular (_MxN_) matrices; any [`MatrixLike`](src/types/matrixLike.ts) input (arrays, typed arrays, custom indexables).
 - **Fast:** _O(M²N)_ time when _M ≤ N_ (_O(MN²)_ otherwise) and only _O(M + N)_ extra memory. [Benchmarks below](#benchmarks).
 - **Typed & dependency-free:** first-class TypeScript types, zero runtime dependencies, ships both ESM and CommonJS.
-- **Robust:** mark forbidden assignments with `Infinity`; built-in [helpers](#helpers) for building and transforming matrices.
+- **Robust:** force an assignment with `-Infinity` or avoid one with `Infinity`; built-in [helpers](#helpers) for building and transforming matrices.
 
 ## Install
 
@@ -72,14 +72,14 @@ const assignments = munkres(costMatrix);
 
 Runs the algorithm and returns a set of optimal `[y, x]` assignment pairs. If several optimal assignments exist, one is returned.
 
-- **`costMatrix`**: a `MatrixLike<number>` or `MatrixLike<bigint>` where `costMatrix[y][x]` is the cost of assigning worker `y` to job `x`. Use `Infinity` / `-Infinity` to forbid an assignment.
+- **`costMatrix`**: a `MatrixLike<number>` or `MatrixLike<bigint>` where `costMatrix[y][x]` is the cost of assigning worker `y` to job `x`. Costs are minimized, so use `-Infinity` to force an assignment (chosen whenever possible) and `Infinity` to avoid one (used only as a last resort, when no finite alternative exists).
 - **`options.finite`** _(boolean, default `false`)_: promise the matrix is all-finite and in-range, skipping input validation for a small speedup on large matrices. If the promise is broken, the result is undefined (it won't throw). See [`MunkresOptions`](src/munkres.options.ts).
 
 **Returns** `Pair<number>[]`, an array of `[y, x]` pairs, length `min(rows, cols)`.
 
 **Throws**
 
-- `TypeError`: a `number` matrix contains `NaN`. (Use `Infinity` to forbid an assignment instead.)
+- `TypeError`: a `number` matrix contains `NaN`. (Use `Infinity` to avoid an assignment instead.)
 - `RangeError`: a `number` matrix's value range (`max - min`) exceeds `Number.MAX_VALUE / 2` and could overflow. Scale the matrix down, or use `bigint`.
 
 > **Precision:** the `number` path uses 64-bit floats. For integer costs that need an exact optimum (especially near or beyond `Number.MAX_SAFE_INTEGER`), use a `bigint` matrix for arbitrary precision.

--- a/src/core/munkres.ts
+++ b/src/core/munkres.ts
@@ -75,7 +75,7 @@ export function exec<T extends number | bigint>(
     throw new TypeError(
       `munkres: cost matrix contains NaN at ` +
         `[${inspection.nanAt[0]}][${inspection.nanAt[1]}]. ` +
-        `Use Infinity to mark forbidden assignments.`,
+        `Use Infinity to avoid an assignment.`,
     );
   }
 

--- a/src/munkres.ts
+++ b/src/munkres.ts
@@ -22,7 +22,7 @@ import type { MunkresOptions } from "./munkres.options.ts";
  * result; when `cols > rows`, the unmatched columns are absent.
  *
  * @throws TypeError if a `number` cost matrix contains `NaN`. Pass
- *   `Infinity` to mark forbidden assignments instead.
+ *   `Infinity` to avoid an assignment instead.
  * @throws RangeError if a `number` cost matrix's range
  *   `max(c) - min(c)` exceeds `Number.MAX_VALUE / 2`, the algorithm's
  *   worst-case intermediate magnitude is `2 * range`, and this guard
@@ -33,8 +33,8 @@ import type { MunkresOptions } from "./munkres.options.ts";
  *   The range check applies only to all-finite matrices. A `number`
  *   matrix containing `Infinity` / `-Infinity` routes to a separate
  *   Infinity-handling path *before* the range check and is therefore
- *   never range-checked — those inputs cannot overflow the same way,
- *   since the forbidden cells are saturated rather than summed.
+ *   never range-checked. Those inputs cannot overflow the same way,
+ *   since the `±Infinity` cells are saturated rather than summed.
  *
  *   Pass `{ finite: true }` to skip BOTH the finiteness scan AND this
  *   range check, when the caller has already established the input is


### PR DESCRIPTION
## Summary
The README and several doc comments described both `Infinity` and `-Infinity` as marking "forbidden" assignments. That is wrong: the cost matrix is **minimized**, so the two signs do opposite things.

Verified by running the algorithm on crafted 2x2 matrices:

| Matrix (minimization) | Result | Meaning |
|---|---|---|
| `-Infinity` at `[0][1]` | `[[0,1],[1,0]]` (cell chosen) | `-Infinity` is always preferred |
| `Infinity` at `[0][1]` | `[[0,0],[1,1]]` (cell avoided) | `Infinity` is avoided |
| row 0 all `Infinity` (forced) | `[[0,0],[1,1]]` (cell used anyway) | `Infinity` is last resort, not truly forbidden |

## Changes
- README: feature bullet, `costMatrix` parameter doc, and the `TypeError` note.
- Public `munkres()` JSDoc: the `@throws TypeError` hint and the range-check remark (`±Infinity` cells saturate rather than sum; also dropped an em dash there).
- The `NaN` `TypeError` message: "mark forbidden assignments" → "avoid an assignment".

No behavior change. The `NaN` error still contains `NaN` and the offending coordinates, so existing tests are unaffected.

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm run test` (356 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)